### PR TITLE
fix semi joins not being supported

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -282,6 +282,16 @@ class BabelParserTest extends SqlParserTest {
         + "FROM (VALUES (ROW(1, 2))) AS `TBL` (`X`, `Y`)");
   }
 
+  @Test void testLeftSemiJoin() {
+    final String sql = "SELECT e.empno\n"
+        + "FROM emp e\n"
+        + "LEFT SEMI JOIN dept d\n"
+        + "ON (a.deptno = d.deptno)";
+    sql(sql).ok("SELECT `E`.`EMPNO`\n"
+        + "FROM `EMP` AS `E`\n"
+        + "LEFT SEMI JOIN `DEPT` AS `D` ON (`A`.`DEPTNO` = `D`.`DEPTNO`)");
+  }
+
   @Test void testCreateTableWithNoCollectionTypeSpecified() {
     final String sql = "create table foo (bar integer not null, baz varchar(30))";
     final String expected = "CREATE TABLE `FOO` (`BAR` INTEGER NOT NULL, `BAZ` VARCHAR(30))";

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -3310,6 +3310,8 @@ public class SqlToRelConverter {
       return JoinRelType.LEFT;
     case RIGHT:
       return JoinRelType.RIGHT;
+    case LEFT_SEMI_JOIN:
+      return JoinRelType.SEMI;
     default:
       throw Util.unexpected(joinType);
     }


### PR DESCRIPTION
the test doesn't actually confirm that this fix works, probably need to add a new kind of test to BabelParser tests that also use SqlToRelConverter
Fix was tested with QueryEngine